### PR TITLE
Update co_closure.h

### DIFF
--- a/co_closure.h
+++ b/co_closure.h
@@ -21,6 +21,7 @@
 struct stCoClosure_t 
 {
 public:
+	virtual ~stCoClosure_t() {}
 	virtual void exec() = 0;
 };
 


### PR DESCRIPTION
fix compile warning:
warning: 'class main(int, char**)::f' has virtual functions but non-virtual destructor
warning: 'class main(int, char**)::f2' has virtual functions but non-virtual destructor